### PR TITLE
Correct filename case in #include directive

### DIFF
--- a/src/lib/Discovery.cpp
+++ b/src/lib/Discovery.cpp
@@ -1,5 +1,5 @@
 #ifdef ESP8266
-#include "discovery.h"
+#include "Discovery.h"
 
 static uint32_t device_ip;
 static char device_name[33];


### PR DESCRIPTION
Use of incorrect filename case causes compilation to fail on filename case-sensitive operating systems like Linux.